### PR TITLE
feat: Implement Phase 2 Logic and Initial Win/Draw Animations

### DIFF
--- a/lib/painters/super_winning_line_painter.dart
+++ b/lib/painters/super_winning_line_painter.dart
@@ -1,0 +1,42 @@
+import 'package:flutter/material.dart';
+
+class SuperWinningLinePainter extends CustomPainter {
+  final List<Offset>? lineCoords; // Start and End points
+  final String? winner; // 'X' or 'O'
+  final double progress;
+
+  SuperWinningLinePainter({
+    this.lineCoords,
+    this.winner,
+    required this.progress,
+  });
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    if (lineCoords == null || lineCoords!.isEmpty || winner == null || progress == 0) return;
+
+    final paint = Paint()
+      ..color = (winner == 'X') ? const Color(0xFFFF3860) : const Color(0xFF209CEE)
+      ..strokeWidth = 15.0 // Thicker line
+      ..style = PaintingStyle.stroke
+      ..strokeCap = StrokeCap.round;
+
+    Offset startPoint = lineCoords![0];
+    Offset endPoint = lineCoords![1];
+    
+    Path path = Path();
+    path.moveTo(startPoint.dx, startPoint.dy);
+    path.lineTo(
+      startPoint.dx + (endPoint.dx - startPoint.dx) * progress,
+      startPoint.dy + (endPoint.dy - startPoint.dy) * progress,
+    );
+    canvas.drawPath(path, paint);
+  }
+
+  @override
+  bool shouldRepaint(covariant SuperWinningLinePainter oldDelegate) {
+    return oldDelegate.lineCoords != lineCoords || 
+           oldDelegate.winner != winner ||
+           oldDelegate.progress != progress;
+  }
+}

--- a/lib/painters/winning_line_painter.dart
+++ b/lib/painters/winning_line_painter.dart
@@ -1,0 +1,43 @@
+import 'package:flutter/material.dart';
+
+class WinningLinePainter extends CustomPainter {
+  final List<Offset> lineCoords; // Start and End points
+  final String player; // 'X' or 'O'
+  final double progress;
+
+  WinningLinePainter({
+    required this.lineCoords,
+    required this.player,
+    required this.progress,
+  });
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    if (lineCoords.isEmpty || progress == 0) return;
+
+    final paint = Paint()
+      ..color = (player == 'X') ? const Color(0xFFFF3860) : const Color(0xFF209CEE) // Red for X, Blue for O
+      ..strokeWidth = 10.0 // As per spec
+      ..style = PaintingStyle.stroke
+      ..strokeCap = StrokeCap.round;
+
+    Offset startPoint = lineCoords[0];
+    Offset endPoint = lineCoords[1];
+    
+    // Animate drawing the line
+    Path path = Path();
+    path.moveTo(startPoint.dx, startPoint.dy);
+    path.lineTo(
+      startPoint.dx + (endPoint.dx - startPoint.dx) * progress,
+      startPoint.dy + (endPoint.dy - startPoint.dy) * progress,
+    );
+    canvas.drawPath(path, paint);
+  }
+
+  @override
+  bool shouldRepaint(covariant WinningLinePainter oldDelegate) {
+    return oldDelegate.lineCoords != lineCoords || 
+           oldDelegate.player != player || 
+           oldDelegate.progress != progress;
+  }
+}

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -3,21 +3,39 @@ import 'package:provider/provider.dart';
 import '../logic/game_state.dart';
 import '../widgets/super_board_widget.dart';
 
-class HomeScreen extends StatelessWidget {
+class HomeScreen extends StatefulWidget { // Changed to StatefulWidget
   const HomeScreen({super.key});
 
   @override
-  Widget build(BuildContext context) {
-    final gameState = Provider.of<GameState>(context); // Get gameState for status and reset
+  State<HomeScreen> createState() => _HomeScreenState();
+}
 
+class _HomeScreenState extends State<HomeScreen> { // New State class
+  Key _superBoardKey = UniqueKey(); // Initial key
+
+  void _resetGame(GameState gameState) {
+    gameState.resetGame();
+    setState(() {
+      _superBoardKey = UniqueKey(); // Generate a new key to force rebuild
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final gameState = Provider.of<GameState>(context);
+    // ... (statusText logic remains the same) ...
     String statusText;
-    if (!gameState.gameActive) { // Assuming gameActive will be set to false on win/draw later
-      statusText = "Game Over!"; // Placeholder, will be refined with actual winner
-    } else {
+    if (!gameState.gameActive && gameState.overallWinner != null) {
+      switch (gameState.overallWinner) {
+        case 'X': statusText = "PLAYER X WINS THE SUPER GAME! 🎉"; break;
+        case 'O': statusText = "PLAYER O WINS THE SUPER GAME! 🎉"; break;
+        case 'DRAW': statusText = "SUPER GAME IS A DRAW! 🤝"; break;
+        default: statusText = "Game Over!"; 
+      }
+    } else { 
       String player = gameState.currentPlayer;
       String boardGuidance;
       if (gameState.activeMiniBoardIndex != null) {
-        // Adjust for 0-indexed to 1-indexed for display if desired, or keep 0-indexed
         int displayBoardIndex = gameState.activeMiniBoardIndex! + 1; 
         boardGuidance = "Play in Board #$displayBoardIndex.";
       } else {
@@ -27,48 +45,32 @@ class HomeScreen extends StatelessWidget {
     }
 
     return Scaffold(
-      appBar: AppBar(
-        title: const Text('Super Tic Tac Toe'),
-      ),
+      appBar: AppBar(title: const Text('Super Tic Tac Toe')),
       body: Center(
-        child: Column( // Use Column to arrange board, status, and button
+        child: Column(
           mainAxisAlignment: MainAxisAlignment.center,
           children: <Widget>[
-            // Title could be here if not in AppBar, or additional titles
-            // const Text('Super Tic Tac Toe', style: TextStyle(fontSize: 24, fontWeight: FontWeight.bold)),
-            // const SizedBox(height: 10),
-
             Container(
               width: 400,
               height: 400,
               padding: const EdgeInsets.all(8.0),
               color: Colors.grey[200],
-              child: const SuperBoardWidget(),
+              child: SuperBoardWidget(key: _superBoardKey), // Use the key here
             ),
-            const SizedBox(height: 20), // Spacing
+            const SizedBox(height: 20),
             Padding(
               padding: const EdgeInsets.symmetric(horizontal: 16.0),
-              child: Text(
-                statusText,
-                style: const TextStyle(fontSize: 18, fontWeight: FontWeight.w500),
-                textAlign: TextAlign.center,
-              ),
+              child: Text(statusText, style: const TextStyle(fontSize: 18, fontWeight: FontWeight.w500), textAlign: TextAlign.center),
             ),
-            const SizedBox(height: 20), // Spacing
+            const SizedBox(height: 20),
             ElevatedButton(
               onPressed: () {
-                gameState.resetGame();
-                // Optionally, re-trigger animations if they don't reset automatically
-                // This might require more complex state management or passing down a key to SuperBoardWidget
-                // For now, resetGame in GameState should clear marks and reset player/active board.
-                // Grid animations are typically only on initial build.
+                _resetGame(gameState); // Call the new reset method
               },
-              style: ElevatedButton.styleFrom(
-                padding: const EdgeInsets.symmetric(horizontal: 30, vertical: 15),
-              ),
+              style: ElevatedButton.styleFrom(padding: const EdgeInsets.symmetric(horizontal: 30, vertical: 15)),
               child: const Text('Reset Super Game', style: TextStyle(fontSize: 16)),
             ),
-            const SizedBox(height: 20), // Bottom spacing
+            const SizedBox(height: 20),
           ],
         ),
       ),

--- a/lib/widgets/mini_board_widget.dart
+++ b/lib/widgets/mini_board_widget.dart
@@ -1,6 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import '../painters/mini_grid_painter.dart';
+import '../painters/x_painter.dart'; 
+import '../painters/o_painter.dart'; 
+import '../painters/winning_line_painter.dart'; 
 import 'cell_widget.dart';
 import '../logic/game_state.dart';
 
@@ -8,12 +11,14 @@ class MiniBoardWidget extends StatefulWidget {
   final int miniBoardIndex;
   final bool isPlayable;
   final bool startAnimation; // Trigger from SuperBoardWidget
+  final String? boardStatus; 
 
   const MiniBoardWidget({
     super.key,
     required this.miniBoardIndex,
     required this.isPlayable,
     required this.startAnimation,
+    this.boardStatus, 
   });
 
   @override
@@ -21,82 +26,331 @@ class MiniBoardWidget extends StatefulWidget {
 }
 
 class _MiniBoardWidgetState extends State<MiniBoardWidget>
-    with SingleTickerProviderStateMixin {
+    with TickerProviderStateMixin { 
   late AnimationController _miniGridController;
   late Animation<double> _miniGridAnimation;
+
+  late AnimationController _winAnimationController; 
+  Animation<double>? _winningLineAnimation; 
+  List<Offset>? _winningLineCoords; 
+  String? _winAnimationPlayer; 
+  bool _isWinAnimationPlaying = false;
+
+  // New state variables for draw animation
+  late AnimationController _drawAnimationController;
+  late Animation<double> _drawFadeOutAnimation; 
+  late Animation<double> _drawSymbolFadeInAnimation; 
+  late Animation<double> _drawSymbolScaleUpAnimation; 
+  bool _isDrawAnimationPlaying = false;
 
   @override
   void initState() {
     super.initState();
     _miniGridController = AnimationController(
-      duration: const Duration(milliseconds: 600), // As per spec
+      duration: const Duration(milliseconds: 600), 
       vsync: this,
     );
 
     _miniGridAnimation = CurvedAnimation(
       parent: _miniGridController,
-      curve: const Cubic(0.65, 0, 0.35, 1), // As per spec
+      curve: const Cubic(0.65, 0, 0.35, 1), 
     )..addListener(() {
         setState(() {});
       });
 
-    // Only start animation if the trigger is true
     if (widget.startAnimation) {
       _miniGridController.forward();
     }
+
+    _winAnimationController = AnimationController(
+      duration: const Duration(milliseconds: 500), 
+      vsync: this,
+    );
+
+    // Initialize _drawAnimationController
+    _drawAnimationController = AnimationController(
+      duration: const Duration(milliseconds: 400), 
+      vsync: this,
+    );
   }
 
   @override
   void didUpdateWidget(covariant MiniBoardWidget oldWidget) {
     super.didUpdateWidget(oldWidget);
-    // If startAnimation becomes true and wasn't before, start animation
     if (widget.startAnimation && !oldWidget.startAnimation && !_miniGridController.isAnimating) {
-      _miniGridController.reset(); // Reset if it was somehow played before
+      _miniGridController.reset();
       _miniGridController.forward();
+    }
+
+    if (widget.boardStatus != null && oldWidget.boardStatus == null) { // Board just became decided
+      if (widget.boardStatus == 'DRAW') {
+        // A draw just happened!
+        if (mounted) {
+          _isDrawAnimationPlaying = true;
+          
+          _drawFadeOutAnimation = Tween<double>(begin: 0.0, end: 1.0).animate(
+            CurvedAnimation(
+              parent: _drawAnimationController,
+              curve: const Interval(0.0, 0.75, curve: Curves.easeOut),
+            )
+          )..addListener(() { setState(() {}); });
+
+          _drawSymbolFadeInAnimation = Tween<double>(begin: 0.0, end: 1.0).animate(
+            CurvedAnimation(
+              parent: _drawAnimationController,
+              curve: const Interval(0.25, 1.0, curve: Curves.easeIn),
+            )
+          )..addListener(() { setState(() {}); });
+          
+          _drawSymbolScaleUpAnimation = Tween<double>(begin: 0.5, end: 1.0).animate(
+            CurvedAnimation(
+              parent: _drawAnimationController,
+              curve: const Interval(0.25, 1.0, curve: Curves.elasticOut),
+            )
+          )..addListener(() { setState(() {}); });
+
+          _drawAnimationController.reset();
+          _drawAnimationController.forward().whenCompleteOrCancel(() {
+              if (mounted && _drawAnimationController.status == AnimationStatus.completed) {
+                  setState(() { _isDrawAnimationPlaying = false; });
+              }
+          });
+        }
+      } else { // A win ('X' or 'O') just happened
+        final gameState = Provider.of<GameState>(context, listen: false);
+        List<String?> currentMiniBoardCells = gameState.miniBoardStates[widget.miniBoardIndex];
+        
+        if (mounted) {
+            WidgetsBinding.instance.addPostFrameCallback((_) {
+                if (!mounted) return; 
+                final boardSize = context.size; 
+                if (boardSize != null) {
+                    _winningLineCoords = _calculateWinningLineCoords(currentMiniBoardCells, boardSize);
+                    if (_winningLineCoords != null) {
+                        _isWinAnimationPlaying = true;
+                        _winningLineAnimation = Tween<double>(begin: 0.0, end: 1.0).animate(
+                            CurvedAnimation(parent: _winAnimationController, curve: Curves.easeInOut)
+                        )..addListener(() { setState(() {}); })
+                         ..addStatusListener((status) {
+                            if (status == AnimationStatus.completed) {
+                                if (mounted) {
+                                    // setState(() { _isWinAnimationPlaying = false; }); // Stage 1 complete
+                                }
+                            }
+                         });
+                        _winAnimationController.reset();
+                        _winAnimationController.forward();
+                    }
+                }
+            });
+        }
+      }
+    } else if (widget.boardStatus == null && oldWidget.boardStatus != null) {
+      // Board was reset
+      _winAnimationController.reset();
+      _drawAnimationController.reset(); // Also reset draw controller
+      _isWinAnimationPlaying = false;
+      _isDrawAnimationPlaying = false; // Add this
+      _winningLineCoords = null;
+      _winAnimationPlayer = null;
     }
   }
 
   @override
   void dispose() {
     _miniGridController.dispose();
+    _winAnimationController.dispose(); 
+    _drawAnimationController.dispose(); // Add this
     super.dispose();
+  }
+
+  List<Offset>? _calculateWinningLineCoords(List<String?> boardCells, Size boardSize) {
+    const List<List<int>> winPatterns = [
+      [0,1,2],[3,4,5],[6,7,8],[0,3,6],[1,4,7],[2,5,8],[0,4,8],[2,4,6]
+    ];
+    String? winner;
+    List<int>? patternIndices;
+
+    for (var pattern in winPatterns) {
+      String? p1 = boardCells[pattern[0]];
+      String? p2 = boardCells[pattern[1]];
+      String? p3 = boardCells[pattern[2]];
+      if (p1 != null && p1 == p2 && p1 == p3) {
+        winner = p1;
+        patternIndices = pattern;
+        break;
+      }
+    }
+
+    if (winner == null || patternIndices == null) return null;
+    _winAnimationPlayer = winner; 
+
+    double cellWidth = boardSize.width / 3;
+    double cellHeight = boardSize.height / 3;
+
+    Offset getCellCenter(int index) {
+      int row = index ~/ 3;
+      int col = index % 3;
+      return Offset(col * cellWidth + cellWidth / 2, row * cellHeight + cellHeight / 2);
+    }
+
+    double extension = (35 / 300) * boardSize.width;
+    Offset startCellCenter = getCellCenter(patternIndices[0]);
+    Offset endCellCenter = getCellCenter(patternIndices[2]);
+    
+    Offset lineDirection = endCellCenter - startCellCenter;
+    double distance = lineDirection.distance;
+    if (distance == 0) return null; 
+    lineDirection = lineDirection.scale(1 / distance, 1 / distance); 
+    
+    Offset extendedStart = startCellCenter - lineDirection * extension;
+    Offset extendedEnd = endCellCenter + lineDirection * extension;
+    
+    return [extendedStart, extendedEnd];
   }
 
   @override
   Widget build(BuildContext context) {
-    final gameState = Provider.of<GameState>(context);
+    final gameState = Provider.of<GameState>(context, listen: false); 
 
-    return AspectRatio(
-      aspectRatio: 1.0,
-      child: CustomPaint(
-        painter: MiniGridPainter(
-          isPlayable: widget.isPlayable,
-          progress: _miniGridAnimation.value,
-        ),
-        child: GridView.builder(
-          physics: const NeverScrollableScrollPhysics(),
-          gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
-            crossAxisCount: 3,
-          ),
-          itemCount: 9,
-          itemBuilder: (context, cellIndex) {
-            String? cellMark = gameState.getCellState(widget.miniBoardIndex, cellIndex);
-            bool isCellActuallyPlayable = widget.isPlayable && cellMark == null;
-
-            return CellWidget(
-              miniBoardIndex: widget.miniBoardIndex,
-              cellIndexInMiniBoard: cellIndex,
-              mark: cellMark,
-              isPlayableCell: isCellActuallyPlayable,
-              onTap: () {
-                if (isCellActuallyPlayable) {
-                  gameState.makeMove(widget.miniBoardIndex, cellIndex);
-                }
+    if (_isWinAnimationPlaying && _winningLineCoords != null && _winningLineAnimation != null && _winAnimationPlayer != null) {
+      return AspectRatio(
+        aspectRatio: 1.0,
+        child: Stack(
+          children: [
+            CustomPaint(
+              painter: MiniGridPainter(
+                isPlayable: false, 
+                progress: 1.0, 
+              ),
+              size: Size.infinite,
+            ),
+            GridView.builder(
+              physics: const NeverScrollableScrollPhysics(),
+              gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(crossAxisCount: 3),
+              itemCount: 9,
+              itemBuilder: (context, cellIndex) {
+                String? cellMark = gameState.getCellState(widget.miniBoardIndex, cellIndex);
+                return CellWidget( 
+                  miniBoardIndex: widget.miniBoardIndex,
+                  cellIndexInMiniBoard: cellIndex,
+                  mark: cellMark,
+                  isPlayableCell: false, 
+                  onTap: null,
+                );
               },
-            );
-          },
+            ),
+            CustomPaint(
+              painter: WinningLinePainter(
+                lineCoords: _winningLineCoords!,
+                player: _winAnimationPlayer!,
+                progress: _winningLineAnimation!.value,
+              ),
+              size: Size.infinite,
+            ),
+          ],
         ),
-      ),
-    );
+      );
+    } else if (_isDrawAnimationPlaying) {
+        // Draw Animation is Playing
+        return AspectRatio(
+          aspectRatio: 1.0,
+          child: Stack(
+            alignment: Alignment.center,
+            children: [
+              // Fading out Grid and Marks
+              Opacity(
+                opacity: 1.0 - _drawFadeOutAnimation.value, // Fade out
+                child: Transform.scale(
+                  scale: 1.0 - (_drawFadeOutAnimation.value * 0.5), // Scale down slightly
+                  child: Stack( // Keep grid and marks together for unified fade/scale
+                    children: [
+                       CustomPaint(
+                        painter: MiniGridPainter(
+                          isPlayable: false, // Not playable during animation
+                          progress: 1.0,   // Grid fully drawn initially
+                        ),
+                        size: Size.infinite,
+                      ),
+                      GridView.builder(
+                        physics: const NeverScrollableScrollPhysics(),
+                        gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(crossAxisCount: 3),
+                        itemCount: 9,
+                        itemBuilder: (context, cellIndex) {
+                          String? cellMark = gameState.getCellState(widget.miniBoardIndex, cellIndex);
+                          return CellWidget(
+                            miniBoardIndex: widget.miniBoardIndex,
+                            cellIndexInMiniBoard: cellIndex,
+                            mark: cellMark,
+                            isPlayableCell: false, // Not playable
+                            onTap: null,
+                          );
+                        },
+                      ),
+                    ]
+                  ),
+                ),
+              ),
+              // Fading and Scaling IN '½' Symbol
+              Opacity(
+                opacity: _drawSymbolFadeInAnimation.value,
+                child: Transform.scale(
+                  scale: _drawSymbolScaleUpAnimation.value,
+                  child: const Center(
+                    child: Text(
+                      '½',
+                      style: TextStyle(fontSize: 40, fontWeight: FontWeight.bold, color: Colors.grey),
+                    ),
+                  ),
+                ),
+              ),
+            ],
+          ),
+        );
+    } else if (widget.boardStatus != null) { 
+      Widget finalDisplay;
+      switch (widget.boardStatus) {
+        case 'X':
+          finalDisplay = CustomPaint(painter: XPainter(progress: 1.0), size: Size.infinite);
+          break;
+        case 'O':
+          finalDisplay = CustomPaint(painter: OPainter(progress: 1.0), size: Size.infinite);
+          break;
+        case 'DRAW':
+          finalDisplay = const Center(child: Text('½', style: TextStyle(fontSize: 40, fontWeight: FontWeight.bold, color: Colors.grey)));
+          break;
+        default: finalDisplay = const SizedBox.shrink();
+      }
+      return AspectRatio(aspectRatio: 1.0, child: Container(child: finalDisplay));
+
+    } else { 
+      return AspectRatio(
+        aspectRatio: 1.0,
+        child: CustomPaint(
+          painter: MiniGridPainter(
+            isPlayable: widget.isPlayable,
+            progress: _miniGridAnimation.value,
+          ),
+          child: (_miniGridAnimation.value == 1.0)
+              ? GridView.builder(
+                  physics: const NeverScrollableScrollPhysics(),
+                  gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(crossAxisCount: 3),
+                  itemCount: 9,
+                  itemBuilder: (context, cellIndex) {
+                    String? cellMark = gameState.getCellState(widget.miniBoardIndex, cellIndex);
+                    bool isCellActuallyPlayable = widget.isPlayable && cellMark == null;
+                    return CellWidget(
+                      miniBoardIndex: widget.miniBoardIndex,
+                      cellIndexInMiniBoard: cellIndex,
+                      mark: cellMark,
+                      isPlayableCell: isCellActuallyPlayable,
+                      onTap: () { if (isCellActuallyPlayable) gameState.makeMove(widget.miniBoardIndex, cellIndex); },
+                    );
+                  },
+                )
+              : const SizedBox.shrink(),
+        ),
+      );
+    }
   }
 }

--- a/lib/widgets/super_board_widget.dart
+++ b/lib/widgets/super_board_widget.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import '../painters/super_grid_painter.dart';
+import '../painters/super_winning_line_painter.dart'; // Added import
 import 'mini_board_widget.dart';
 import '../logic/game_state.dart';
 
@@ -12,11 +13,18 @@ class SuperBoardWidget extends StatefulWidget {
 }
 
 class _SuperBoardWidgetState extends State<SuperBoardWidget>
-    with SingleTickerProviderStateMixin {
+    with TickerProviderStateMixin { // Changed to TickerProviderStateMixin
   late AnimationController _mainGridController;
   late Animation<double> _mainGridAnimation;
 
   bool _startMiniBoardAnimations = false;
+
+  // New state variables for super win animation
+  late AnimationController _superWinAnimationController;
+  Animation<double>? _superWinningLineAnimation;
+  List<Offset>? _superWinningLineCoords;
+  String? _superWinnerForAnimation;
+  bool _isSuperWinAnimationPlaying = false; 
 
   @override
   void initState() {
@@ -42,46 +50,146 @@ class _SuperBoardWidgetState extends State<SuperBoardWidget>
         });
       }
     });
+
+    // Initialize _superWinAnimationController
+    _superWinAnimationController = AnimationController(
+      duration: const Duration(milliseconds: 700), // As per spec
+      vsync: this,
+    );
   }
 
   @override
   void dispose() {
     _mainGridController.dispose();
+    _superWinAnimationController.dispose(); // Added dispose
     super.dispose();
   }
+
+  // Helper to calculate super winning line coordinates
+  List<Offset>? _calculateSuperWinningLineCoords(String winner, List<String?> superBoardStatus, Size boardSize) {
+    const List<List<int>> winPatterns = [
+      [0,1,2],[3,4,5],[6,7,8],[0,3,6],[1,4,7],[2,5,8],[0,4,8],[2,4,6]
+    ];
+    List<int>? winningPatternIndices;
+
+    for (var pattern in winPatterns) {
+      String? p1 = superBoardStatus[pattern[0]];
+      String? p2 = superBoardStatus[pattern[1]];
+      String? p3 = superBoardStatus[pattern[2]];
+      if (p1 == winner && p1 == p2 && p1 == p3) { // Check for the specific winner
+        winningPatternIndices = pattern;
+        break;
+      }
+    }
+
+    if (winningPatternIndices == null) return null;
+
+    double miniBoardWidth = boardSize.width / 3;
+    double miniBoardHeight = boardSize.height / 3;
+    
+    Offset getGeometricMiniBoardCenter(int index) {
+      int row = index ~/ 3;
+      int col = index % 3;
+      return Offset(col * miniBoardWidth + miniBoardWidth / 2, row * miniBoardHeight + miniBoardHeight / 2);
+    }
+
+    Offset startCenter = getGeometricMiniBoardCenter(winningPatternIndices[0]);
+    Offset endCenter = getGeometricMiniBoardCenter(winningPatternIndices[2]);
+    
+    return [startCenter, endCenter];
+  }
+
 
   @override
   Widget build(BuildContext context) {
     final gameState = Provider.of<GameState>(context);
     final int? activeMiniBoardIndex = gameState.activeMiniBoardIndex;
+    final String? overallWinner = gameState.overallWinner;
 
-    return AspectRatio(
-      aspectRatio: 1.0,
-      child: CustomPaint(
-        painter: SuperGridPainter(progress: _mainGridAnimation.value),
-        child: GridView.builder(
-          physics: const NeverScrollableScrollPhysics(),
-          gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
-            crossAxisCount: 3,
-          ),
-          itemCount: 9,
-          itemBuilder: (context, index) {
-            // Get the status of the current mini-board
-            String? boardStatus = gameState.superBoardState[index];
+    // Check for overall winner and trigger animation if not already played
+    if (overallWinner != null && overallWinner != 'DRAW' && !_isSuperWinAnimationPlaying && _superWinningLineAnimation == null) {
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+            if (!mounted) return;
+            // Use LayoutBuilder's constraints for size if context.size is not reliable here.
+            // However, for now, let's assume context.size is available from the parent AspectRatio.
+            final boardSize = context.size; 
+            if (boardSize != null) {
+                _superWinningLineCoords = _calculateSuperWinningLineCoords(overallWinner, gameState.superBoardState, boardSize);
+                if (_superWinningLineCoords != null) {
+                    _superWinnerForAnimation = overallWinner;
+                    _isSuperWinAnimationPlaying = true;
 
-            return Padding(
-              padding: const EdgeInsets.all(6.0), // Changed to 6.0
-              child: MiniBoardWidget(
-                miniBoardIndex: index,
-                // Determine isPlayable based on activeMiniBoardIndex AND if the board itself is NOT decided
-                isPlayable: (activeMiniBoardIndex == null || activeMiniBoardIndex == index) && boardStatus == null,
-                startAnimation: _startMiniBoardAnimations,
-                boardStatus: boardStatus, // Pass the board status
+                    _superWinningLineAnimation = Tween<double>(begin: 0.0, end: 1.0).animate(
+                        CurvedAnimation(parent: _superWinAnimationController, curve: Curves.easeInOutCubic)
+                    )..addListener(() { setState(() {}); })
+                     ..addStatusListener((status) {
+                         if (status == AnimationStatus.completed) {
+                             if (mounted) {
+                                 // Keep the line drawn, _isSuperWinAnimationPlaying remains true
+                             }
+                         }
+                     });
+                    
+                    Future.delayed(const Duration(seconds: 1), () { // Simplified delay
+                        if (mounted && _isSuperWinAnimationPlaying) { 
+                           _superWinAnimationController.reset();
+                           _superWinAnimationController.forward();
+                        }
+                    });
+                }
+            }
+        });
+    }
+    
+    if(overallWinner == null && _superWinningLineAnimation != null) {
+        _superWinAnimationController.reset();
+        _superWinningLineAnimation = null;
+        _superWinningLineCoords = null;
+        _superWinnerForAnimation = null;
+        _isSuperWinAnimationPlaying = false;
+    }
+
+    return LayoutBuilder( 
+      builder: (context, constraints) {
+        return Stack(
+          children: [
+            AspectRatio(
+              aspectRatio: 1.0,
+              child: CustomPaint(
+                painter: SuperGridPainter(progress: _mainGridAnimation.value),
+                child: GridView.builder(
+                  physics: const NeverScrollableScrollPhysics(),
+                  gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(crossAxisCount: 3),
+                  itemCount: 9,
+                  itemBuilder: (context, index) {
+                    String? boardStatus = gameState.superBoardState[index];
+                    return Padding(
+                      padding: const EdgeInsets.all(6.0),
+                      child: MiniBoardWidget(
+                        miniBoardIndex: index,
+                        isPlayable: (activeMiniBoardIndex == null || activeMiniBoardIndex == index) && boardStatus == null,
+                        startAnimation: _startMiniBoardAnimations,
+                        boardStatus: boardStatus,
+                      ),
+                    );
+                  },
+                ),
               ),
-            );
-          },
-        ),
-      ),
+            ),
+            if (_isSuperWinAnimationPlaying && _superWinningLineAnimation != null && _superWinningLineCoords != null)
+              Positioned.fill( 
+                child: CustomPaint(
+                  painter: SuperWinningLinePainter(
+                    lineCoords: _superWinningLineCoords,
+                    winner: _superWinnerForAnimation,
+                    progress: _superWinningLineAnimation!.value,
+                  ),
+                  size: constraints.biggest, 
+                ),
+              ),
+          ],
+        );
+      }
     );
   }
 }


### PR DESCRIPTION
Completes Phase 2 Steps 1-10:

GameState:
- Full win/draw logic for mini-boards (_checkMiniBoardWinner) and super-board (_checkOverallWinner).
- `superBoardState` and `overallWinner` properties added and managed.
- `makeMove` updated to use win logic, update game state (gameActive, overallWinner), and correctly implement the "Sent-to-Concluded-Mini-Board" rule.

MiniBoardWidget:
- Displays static 'X', 'O', or '½' when board is decided (after animations).
- Implements Stage 1 of win animation (draws animated winning line with WinningLinePainter).
- Implements full draw animation (fade out old content, fade/scale in '½').

SuperBoardWidget:
- Implements super-board win animation (draws animated line across winning mini-boards with SuperWinningLinePainter).
- Passes correct `boardStatus` to MiniBoardWidgets.

HomeScreen:
- Status display now shows detailed game end messages (X wins, O wins, Draw).
- Reset functionality enhanced to use a Key on SuperBoardWidget to re-trigger initial grid animations.

New Painters:
- WinningLinePainter (for mini-boards).
- SuperWinningLinePainter (for super-board).